### PR TITLE
Fix JSONDecodeError in health check and gateway tests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,8 +57,7 @@ async def forward_request(url: str, method: str, headers: dict, data: dict = Non
 def test_health_check_returns_service_status(client):
     response = client.get("/health")
     assert response.status_code == 200
-    assert "service_a_healthy" in response.json()
-    assert "service_b_healthy" in response.json()
+    assert response.json() == {"service_a_healthy": True, "service_b_healthy": True}
 
 
 def test_gateway_get_returns_200_or_404(client):
@@ -138,11 +137,11 @@ def test_gateway_get_missing_required_fields(client):
     headers = {"Authorization": get_auth_token()}
     response = client.get("/service-a/some-path", headers=headers)
     assert response.status_code == 200
-    assert response.json() is not None or response.json() == {}
+    assert response.json() == {"message": "This is service-a"}
 
 
 def test_gateway_post_missing_required_fields(client):
     headers = {"Authorization": get_auth_token()}
     response = client.post("/service-a/some-path", json={}, headers=headers)
     assert response.status_code == 200
-    assert response.json() is not None or response.json() == {}
+    assert response.json() == {"message": "POST request to service-a", "data": {}}


### PR DESCRIPTION
Update tests to handle JSON responses correctly.

* Update `test_health_check_returns_service_status` in `tests/test_main.py` to assert the correct JSON response.
* Update `test_gateway_get_missing_required_fields` in `tests/test_main.py` to assert the correct JSON response.
* Update `test_gateway_post_missing_required_fields` in `tests/test_main.py` to assert the correct JSON response.

