### PR TITLE
Fix content length error in API Gateway

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -155,3 +155,10 @@ def test_gateway_post_missing_required_fields(client):
         assert response.json() == {"message": "POST request to service-a", "data": {}}
     else:
         assert response.json() == {}
+
+
+def test_too_little_data_for_declared_content_length_error(client):
+    headers = {"Authorization": get_auth_token(), "Content-Length": "100"}
+    response = client.post("/service-a/some-path", headers=headers)
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Too little data for declared Content-Length"}


### PR DESCRIPTION
Add custom exception handler for `h11._util.LocalProtocolError` in `main.py`.

* **main.py**
  - Import `h11` module.
  - Add a custom exception handler for `h11._util.LocalProtocolError`.
  - Log the error and return a 400 Bad Request response with a relevant error message.

* **tests/test_main.py**
  - Add a test case for the 'Too little data for declared Content-Length' error.
  - Verify that the response status code is 400 and the response content matches the expected error message.

